### PR TITLE
Fix: Crash on devices with missing system properties (e.g. Huawei Kirin)

### DIFF
--- a/ab/lite/torch2tflite.py
+++ b/ab/lite/torch2tflite.py
@@ -108,7 +108,9 @@ def setup_benchmark_binary(force=False):
     print(f"[SETUP] Verified: {ver}")
 
 # --- METADATA HELPERS ---
-def adb_getprop(key): return adb_shell(f"getprop {key}").splitlines()[-1]
+def adb_getprop(key):
+    lines = adb_shell(f"getprop {key}").splitlines()
+    return lines[-1] if lines else ""
 
 def get_gpu_name():
     raw = adb_shell("dumpsys SurfaceFlinger | grep GLES")


### PR DESCRIPTION
## Update

Hardens `adb_getprop` against devices that return empty output for system 
properties. Confirmed fix on Huawei Y9 Prime (Kirin 710, EMUI 10); expected 
to help any device where `ro.soc.model` isn't populated, which is common on 
pre-Android-12 devices since that property only became mandatory in API 31.