### PR TITLE
Migrate ai_edge_torch → litert_torch in torch2tflite

### DIFF
--- a/ab/lite/torch2tflite.py
+++ b/ab/lite/torch2tflite.py
@@ -33,7 +33,7 @@ state_file = work_dir / "processing_state_dual.json"
 for p in [int8_dir, fp32_dir, data_root, temp_dl_dir]: 
     p.mkdir(parents=True, exist_ok=True)
 
-import torch, torchvision, torchvision.transforms as T, ai_edge_torch, tensorflow as tf, numpy as np
+import torch, torchvision, torchvision.transforms as T, litert_torch, tensorflow as tf, numpy as np
 from huggingface_hub import hf_hub_download, list_repo_files
 
 # --- GUARDIAN: USB RECONNECTION LOGIC ---
@@ -276,7 +276,7 @@ def main():
             # --- PROCESS FP32 ---
             print(f"   [PROCESS] FP32 Conversion...")
             fp32_tflite = temp_dl_dir / f"{name}_fp32.tflite"
-            ai_edge_torch.convert(model, dummy_input).export(str(fp32_tflite))
+            litert_torch.convert(model, dummy_input).export(str(fp32_tflite))
             
             # --- PROCESS INT8 ---
             print(f"   [PROCESS] INT8 Conversion...")
@@ -288,9 +288,9 @@ def main():
                     for j in range(50): 
                         yield [np.random.randn(1, 3, target_h, target_h).astype(np.float32)]
                 
-                ai_edge_torch.convert(
-                    model, 
-                    dummy_input, 
+                litert_torch.convert(
+                    model,
+                    dummy_input,
                     _ai_edge_converter_flags={
                         'optimizations': [tf.lite.Optimize.DEFAULT], 
                         'representative_dataset': rep, 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ absl-py==2.4.0
 ai-edge-litert-nightly==2.2.0.dev20260202
 ai-edge-quantizer==0.4.0
 ai-edge-quantizer-nightly==0.5.0.dev20260204
-ai-edge-torch-nightly==0.8.0.dev20260122
+litert-torch==0.8.0
 ai_edge_tensorflow==2.21.0.dev20251110
 anyio==4.12.1
 astunparse==1.6.3


### PR DESCRIPTION
Migrates `ab/lite/torch2tflite.py` from the deprecated `ai_edge_torch` package to its
renamed successor `litert_torch`.

## Changes
`ab/lite/torch2tflite.py` — 3 call sites, 1 file:
- **Import (line 36):** `ai_edge_torch` → `litert_torch`
- **FP32 conversion (line 279):** `ai_edge_torch.convert(...)` → `litert_torch.convert(...)`
- **INT8 conversion (line 291):** `ai_edge_torch.convert(...)` → `litert_torch.convert(...)`

The `_ai_edge_converter_flags=` keyword argument is intentionally left unchanged —
`litert_torch` keeps that parameter name for backward compatibility.

No logic, control flow, or the adb/benchmark (on-device latency) path was touched.

## Verification
Ran the FP32 and INT8 conversions end-to-end on **AlexNet** (norm_299 → 299×299 input)
with `litert_torch 0.8.0`:
- **FP32:** torch → tflite export succeeded (~223 MB)
- **INT8:** fully-quantized export succeeded (~56 MB, ~4× smaller), confirmed
  `input_inference_type: INT8, output_inference_type: INT8`

The mobile/adb benchmarking (`benchmark_model`, GPU/NPU/CPU timing) is a latency-only
measurement and is not required to validate the conversion, so it was not exercised.